### PR TITLE
win32: use builtin setjmp/longgmp functions with mingw/llvm compilers…

### DIFF
--- a/code/client/cl_jpeg.c
+++ b/code/client/cl_jpeg.c
@@ -63,7 +63,7 @@ static void CL_JPGErrorExit(j_common_ptr cinfo)
 	Com_Printf( "Error: %s", buffer );
   
 	/* Return control to the setjmp point */
-	longjmp( jerr->setjmp_buffer, 1 );
+	Q_longjmp( jerr->setjmp_buffer, 1 );
 }
 
 
@@ -134,12 +134,12 @@ void CL_LoadJPG( const char *filename, unsigned char **pic, int *width, int *hei
 	cinfo.err->output_message = CL_JPGOutputMessage;
 
 	/* Establish the setjmp return context for R_JPGErrorExit to use. */
-	if (setjmp(jerr.setjmp_buffer))
+	if ( Q_setjmp( jerr.setjmp_buffer ) )
 	{
 		/* If we get here, the JPEG code has signaled an error.
 		* We need to clean up the JPEG object, close the input file, and return.
 		*/
-		jpeg_destroy_decompress(&cinfo);
+		jpeg_destroy_decompress( &cinfo );
 		FS_FreeFile( fbuffer.v );
 
 		/* Append the filename to the error for easier debugging */
@@ -399,7 +399,7 @@ size_t CL_SaveJPGToBuffer(byte *buffer, size_t bufSize, int quality,
   cinfo.err->output_message = CL_JPGOutputMessage;
 
   /* Establish the setjmp return context for R_JPGErrorExit to use. */
-  if ( setjmp( jerr.setjmp_buffer ) )
+  if ( Q_setjmp( jerr.setjmp_buffer ) )
   {
     /* If we get here, the JPEG code has signaled an error.
      * We need to clean up the JPEG object and return.

--- a/code/qcommon/common.c
+++ b/code/qcommon/common.c
@@ -52,7 +52,7 @@ const int demo_protocols[] = { 66, 67, PROTOCOL_VERSION, NEW_PROTOCOL_VERSION, 0
 #define DEF_COMZONEMEGS		25
 #endif
 
-jmp_buf abortframe;		// an ERR_DROP occurred, exit the entire frame
+static jmp_buf abortframe;	// an ERR_DROP occurred, exit the entire frame
 
 int		CPU_Flags = 0;
 
@@ -354,7 +354,7 @@ void QDECL Com_Error( errorParm_t code, const char *fmt, ... ) {
 		FS_PureServerSetLoadedPaks( "", "" );
 		com_errorEntered = qfalse;
 
-		longjmp( abortframe, 1 );
+		Q_longjmp( abortframe, 1 );
 	} else if ( code == ERR_DROP ) {
 		Com_Printf( "********************\nERROR: %s\n********************\n",
 			com_errorMessage );
@@ -370,7 +370,7 @@ void QDECL Com_Error( errorParm_t code, const char *fmt, ... ) {
 		FS_PureServerSetLoadedPaks( "", "" );
 		com_errorEntered = qfalse;
 
-		longjmp( abortframe, 1 );
+		Q_longjmp( abortframe, 1 );
 	} else if ( code == ERR_NEED_CD ) {
 		SV_Shutdown( "Server didn't have CD" );
 		Com_EndRedirect();
@@ -388,7 +388,7 @@ void QDECL Com_Error( errorParm_t code, const char *fmt, ... ) {
 		FS_PureServerSetLoadedPaks( "", "" );
 		com_errorEntered = qfalse;
 
-		longjmp( abortframe, 1 );
+		Q_longjmp( abortframe, 1 );
 	} else {
 		VM_Forced_Unload_Start();
 #ifndef DEDICATED
@@ -3556,7 +3556,7 @@ void Com_Init( char *commandLine ) {
 
 	Com_Printf( "%s %s %s\n", SVN_VERSION, PLATFORM_STRING, __DATE__ );
 
-	if ( setjmp (abortframe) ) {
+	if ( Q_setjmp( abortframe ) ) {
 		Sys_Error ("Error during initialization");
 	}
 
@@ -3979,7 +3979,7 @@ void Com_Frame( qboolean noDelay ) {
 	int	timeBeforeClient;
 	int	timeAfter;
 
-	if ( setjmp( abortframe ) ) {
+	if ( Q_setjmp( abortframe ) ) {
 		return;			// an ERR_DROP was thrown
 	}
 

--- a/code/qcommon/puff.c
+++ b/code/qcommon/puff.c
@@ -120,7 +120,7 @@ local int32_t bits(struct state *s, int32_t need)
     /* load at least need bits into val */
     val = s->bitbuf;
     while (s->bitcnt < need) {
-        if (s->incnt == s->inlen) longjmp(s->env, 1);   /* out of input */
+        if (s->incnt == s->inlen) Q_longjmp(s->env, 1);   /* out of input */
         val |= (int32_t)(s->in[s->incnt++]) << s->bitcnt;  /* load eight bits */
         s->bitcnt += 8;
     }
@@ -252,7 +252,7 @@ local int32_t decode(struct state *s, struct huffman *h)
         }
         left = (MAXBITS+1) - len;
         if (left == 0) break;
-        if (s->incnt == s->inlen) longjmp(s->env, 1);   /* out of input */
+        if (s->incnt == s->inlen) Q_longjmp(s->env, 1);   /* out of input */
         bitbuf = s->in[s->incnt++];
         if (left > 8) left = 8;
     }
@@ -740,7 +740,7 @@ int32_t puff(uint8_t  *dest,           /* pointer to destination pointer */
     s.bitcnt = 0;
 
     /* return if bits() or decode() tries to read past available input */
-    if (setjmp(s.env) != 0)             /* if came back here via longjmp() */
+    if ( Q_setjmp( s.env ) != 0 )       /* if came back here via longjmp() */
         err = 2;                        /* then skip do-loop, return error */
     else {
         /* process blocks until last block or error */

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -174,6 +174,14 @@ float FloatSwap( const float *f );
 	#endif
 #endif
 
+#if defined (_WIN32) && !defined(_MSC_VER)
+#define Q_setjmp __builtin_setjmp
+#define Q_longjmp __builtin_longjmp
+#else
+#define Q_setjmp setjmp
+#define Q_longjmp longjmp
+#endif
+
 typedef unsigned char byte;
 
 typedef enum { qfalse = 0, qtrue } qboolean;


### PR DESCRIPTION
… to avoid problems with hardened longjmp in recent win10 versions